### PR TITLE
Added support for chrome launching on linux

### DIFF
--- a/Lib.Test/ChromePathFinderTest.cs
+++ b/Lib.Test/ChromePathFinderTest.cs
@@ -1,0 +1,25 @@
+using System;
+using Lib.Chrome;
+using Xunit;
+
+
+namespace Lib.Test
+{
+    public class ChromePathFinderTest {
+
+
+        [Fact]
+        void ReturnsWindowsPathIfNotUnixFs()
+        {
+            var chromePath = ChromePathFinder.GetChromePath(false);
+            Assert.Equal(@"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe", chromePath);
+        }
+
+        [Fact]
+        void ReturnsLinuxPathIfIsUnixFs() {
+            var chromePath = ChromePathFinder.GetChromePath(true);
+            Assert.Equal("/opt/google/chrome/google-chrome", chromePath);
+        }
+    }
+
+}

--- a/Lib/Chrome/ChromePathFinder.cs
+++ b/Lib/Chrome/ChromePathFinder.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Lib.Chrome {
+
+    public static class ChromePathFinder {
+
+        const string WindowsChromePath = @"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe";
+        const string LinuxChromePath = "/opt/google/chrome/google-chrome";
+
+        public static string GetChromePath(bool isUnixFs) {
+            if (isUnixFs) {
+                return LinuxChromePath;
+            } else {
+                return WindowsChromePath;
+            }
+        }
+    }
+
+}

--- a/Lib/Composition/Composition.cs
+++ b/Lib/Composition/Composition.cs
@@ -388,7 +388,8 @@ namespace Lib.Composition
         {
             if (_chromeProcessFactory == null)
             {
-                _chromeProcessFactory = new ChromeProcessFactory();
+                var chromePath = ChromePathFinder.GetChromePath(PathUtils.IsUnixFs);
+                _chromeProcessFactory = new ChromeProcessFactory(chromePath);
             }
             if (_chromeProcess == null)
             {

--- a/bb/build.sh
+++ b/bb/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+dotnet publish -c Release -r win10-x64 /p:ShowLinkerSizeComparison=true
+dotnet publish -c Release -r linux-x64 /p:ShowLinkerSizeComparison=true


### PR DESCRIPTION
I've added and tested chrome launching on linux. 
Path that is used is based on https://stackoverflow.com/questions/11465688/how-do-i-get-the-path-of-the-chrome-executable-on-ubuntu-10-09 

It seems that standard linux installation always goes to /opt/google/chrome/google-chrome 
This is true both for standart package for ubuntu and also for aur(ArchLinux user repository) distributed package. 
Tested on Linux manjaro 4.9.68-1-MANJARO 

Also I've added build.sh script for release build on linux. 