### PR TITLE
Linux added support for chromium

### DIFF
--- a/Lib.Test/ChromePathFinderTest.cs
+++ b/Lib.Test/ChromePathFinderTest.cs
@@ -1,0 +1,25 @@
+using System;
+using Lib.Chrome;
+using Xunit;
+
+
+namespace Lib.Test
+{
+    public class ChromePathFinderTest {
+
+
+        [Fact]
+        void ReturnsWindowsPathIfNotUnixFs()
+        {
+            var chromePath = ChromePathFinder.GetChromePath(false);
+            Assert.Equal(@"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe", chromePath);
+        }
+
+        [Fact]
+        void ReturnsLinuxPathIfIsUnixFs() {
+            var chromePath = ChromePathFinder.GetChromePath(true);
+            Assert.Equal("/opt/google/chrome/google-chrome", chromePath);
+        }
+    }
+
+}

--- a/Lib.Test/TSCompilerTests.cs
+++ b/Lib.Test/TSCompilerTests.cs
@@ -133,6 +133,11 @@ namespace Lib.Test
                 AddTextFile(PathUtils.Join(path, f.Name), nfs.ReadAllUtf8(PathUtils.Join(path, f.Name)));
             }
         }
+
+        public bool FileExists(string path)
+        {
+            return true;
+        }
     }
 
     public class CompilerTests

--- a/Lib/Chrome/ChromePathFinder.cs
+++ b/Lib/Chrome/ChromePathFinder.cs
@@ -1,18 +1,44 @@
 using System;
+using System.IO;
+using Lib.DiskCache;
 
-namespace Lib.Chrome {
+namespace Lib.Chrome
+{
 
-    public static class ChromePathFinder {
+    public static class ChromePathFinder
+    {
 
         const string WindowsChromePath = @"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe";
         const string LinuxChromePath = "/opt/google/chrome/google-chrome";
+        static readonly string[] LinuxChromiumPaths = { "/usr/bin/chromium", "/usr/bin/chromium-browser" };
 
-        public static string GetChromePath(bool isUnixFs) {
-            if (isUnixFs) {
-                return LinuxChromePath;
-            } else {
+        public static string GetChromePath(IFsAbstraction fsAbstratction)
+        {
+            if (fsAbstratction.IsUnixFs)
+            {
+                return GetLinuxChromePath(fsAbstratction);
+            }
+            else
+            {
                 return WindowsChromePath;
             }
+        }
+
+        static string GetLinuxChromePath(IFsAbstraction fsAbstratction)
+        {
+            if (fsAbstratction.FileExists(LinuxChromePath))
+            {
+                return LinuxChromePath;
+            }
+
+            foreach (string chromiumPath in LinuxChromiumPaths)
+            {
+                if (fsAbstratction.FileExists(chromiumPath))
+                {
+                    return chromiumPath;
+                }
+            }
+            throw new Exception("Chrome not found. Install Google Chrome or Chromium.");
         }
     }
 

--- a/Lib/Chrome/ChromePathFinder.cs
+++ b/Lib/Chrome/ChromePathFinder.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Lib.Chrome {
+
+    public static class ChromePathFinder {
+
+        const string WindowsChromePath = @"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe";
+        const string LinuxChromePath = "/opt/google/chrome/google-chrome";
+
+        public static string GetChromePath(bool isUnixFs) {
+            if (isUnixFs) {
+                return LinuxChromePath;
+            } else {
+                return WindowsChromePath;
+            }
+        }
+    }
+
+}

--- a/Lib/Composition/Composition.cs
+++ b/Lib/Composition/Composition.cs
@@ -388,7 +388,8 @@ namespace Lib.Composition
         {
             if (_chromeProcessFactory == null)
             {
-                _chromeProcessFactory = new ChromeProcessFactory();
+                var chromePath = ChromePathFinder.GetChromePath(PathUtils.IsUnixFs);
+                _chromeProcessFactory = new ChromeProcessFactory(chromePath);
             }
             if (_chromeProcess == null)
             {

--- a/Lib/Composition/Composition.cs
+++ b/Lib/Composition/Composition.cs
@@ -390,7 +390,7 @@ namespace Lib.Composition
         {
             if (_chromeProcessFactory == null)
             {
-                var chromePath = ChromePathFinder.GetChromePath(PathUtils.IsUnixFs);
+                var chromePath = ChromePathFinder.GetChromePath(new NativeFsAbstraction());
                 _chromeProcessFactory = new ChromeProcessFactory(chromePath);
             }
             if (_chromeProcess == null)

--- a/Lib/DiskCache/IFsAbstraction.cs
+++ b/Lib/DiskCache/IFsAbstraction.cs
@@ -9,5 +9,6 @@ namespace Lib.DiskCache
         IReadOnlyList<FsItemInfo> GetDirectoryContent(string path);
         byte[] ReadAllBytes(string path);
         string ReadAllUtf8(string path);
+        bool FileExists(string path);
     }
 }

--- a/Lib/DiskCache/NativeFsAbstraction.cs
+++ b/Lib/DiskCache/NativeFsAbstraction.cs
@@ -10,6 +10,11 @@ namespace Lib.DiskCache
     {
         public bool IsUnixFs => PathUtils.IsUnixFs;
 
+        public bool FileExists(string path)
+        {
+            return File.Exists(path);
+        }
+
         public IReadOnlyList<FsItemInfo> GetDirectoryContent(string path)
         {
             var res = new List<FsItemInfo>();

--- a/bb/build.sh
+++ b/bb/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+dotnet publish -c Release -r win10-x64 /p:ShowLinkerSizeComparison=true
+dotnet publish -c Release -r linux-x64 /p:ShowLinkerSizeComparison=true


### PR DESCRIPTION
If chrome is not installed on linux machine chormium is looked up as fallback. Most linux users use chroium instead of chrome as it is part of standard linux packages. 

There two possible paths where chromium can be. Most debian base distros (ubuntu, mint etc) uses: /usr/bin/chromium-browser

On arch linux based distros it is: /usr/bin/chromium

Please review this pull request and do CR if there should be some code changes.