### PR TITLE
 Store "R" loader to globalThis.

### DIFF
--- a/Lib/ToolsDir/loader.js
+++ b/Lib/ToolsDir/loader.js
@@ -2,6 +2,12 @@
 const R = function (name, fnOrJson) {
     R.m.set(name.toLowerCase(), typeof fnOrJson == "function" ? { fn: fnOrJson, exports: undefined } : { exports: fnOrJson });
 };
+/*
+ * Store "R" loader to globalThis.
+ * It needs to be globally available for usage in the FastBundleBundler.cs
+ * when code is split into multiple files and files are loaded like ES modules
+ */
+globalThis.R = R;
 R.t = this;
 R.m = new Map();
 R.r = function (name, parent) {

--- a/Lib/ToolsDir/loader.ts
+++ b/Lib/ToolsDir/loader.ts
@@ -18,6 +18,12 @@ const R: IR = function (name: string, fnOrJson: ModuleFun | any) {
         typeof fnOrJson == "function" ? { fn: fnOrJson, exports: undefined } : { exports: fnOrJson }
     );
 };
+/*
+ * Store "R" loader to globalThis.
+ * It needs to be globally available for usage in the FastBundleBundler.cs
+ * when code is split into multiple files and files are loaded like ES modules
+ */
+(globalThis as any).R = R;
 R.t = this;
 R.m = new Map();
 R.r = function (name: string, parent: string) {


### PR DESCRIPTION
 It needs to be globally available for usage in the FastBundleBundler.cs when code is split into multiple files and files are loaded like ES modules.