### PR TITLE
Update version of nodejs from 14 to 18 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y \
 	curl \
 	gnupg \
 	--no-install-recommends \
-	&& curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+	&& curl -sL https://deb.nodesource.com/setup_18.x | bash - \
 	&& curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
 	&& echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
 	&& curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \


### PR DESCRIPTION
Update to latest active version of node.js because of EOL of node.js 14 on 30th april.
https://nodejs.dev/en/about/releases/